### PR TITLE
Implement availability Captcha image directly from object

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -574,6 +574,7 @@ class Captcha(Exception):
 
         self.key = None
         self.url = url
+        self.image = None
 
     def get_url(self):
         """ Возвращает ссылку на изображение капчи
@@ -584,6 +585,14 @@ class Captcha(Exception):
             self.url = 'https://api.vk.com/captcha.php?sid={}'.format(self.sid)
 
         return self.url
+
+    def get_image(self):
+        """ Возвращает бинарное изображение капчи, получаемое по get_url()
+        """
+
+        if not self.image:
+            self.image = self.vk.http.get(self.get_url()).content
+        return self.image
 
     def try_again(self, key):
         """ Отправляет запрос заново с ответом капчи


### PR DESCRIPTION
Суть в том, что при вызове `captcha_handler`, при *асинхронном* выводе картинки капчи, хандлер завершается и `authorization()` падает.
Если же делать запрос картинки *синхронно*, всё отлично.
Конечно, можно оставить выбор пользователю(например, использовать тот же `requests` для отправки запроса капчи), но по-моему, данное небольшое "переиспользование" `self.vk.http` как раз к месту.