### PR TITLE
Изменение рассчета ограничений по времени

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -389,8 +389,8 @@ class VkApi(object):
         if delay > 0:
             time.sleep(delay)
 
-        response = self.http.post(url, values)
         self.last_request = time.time()
+        response = self.http.post(url, values)
 
         if response.ok:
             response = response.json()


### PR DESCRIPTION
@python273 ,
Можно делать 3 *запроса* в секунду, а не 3 обработанных запроса.

Я еще не сильно потестил, но вроде это так. Предлагаю обсудить, в частности, как проверить.

P.S. Я качаю в 32 потока, и, учитывая потокоНЕбезопасность пакета, я вообще не понимаю, почему все работает: ведь до тех пор, пока обработается первый запрос и переустановится `self.last_request`, набежит еще до 31-го запроса... (а значение `self.last_request` всё то же). Следующим пунктом я-таки займусь потокобезопасностью...