### PR TITLE
Фикс: добавляем headers в запрос, а не устанавливаем все

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -86,10 +86,10 @@ class VkApi(object):
 
         self.http = requests.Session()
         self.http.proxies = proxies  # Ставим прокси
-        self.http.headers = {  # Притворимся браузером
+        self.http.headers.update({  # Притворимся браузером
             'User-agent': 'Mozilla/5.0 (Windows NT 6.1; rv:40.0) '
             'Gecko/20100101 Firefox/40.0'
-        }
+        })
 
         self.last_request = 0.0
 


### PR DESCRIPTION
`response.request.headers` before:
```
{'Content-Length': '141', 'User-agent': 'Mozilla/5.0 (Windows NT 6.1; rv:40.0) Gecko/20100101 Firefox/40.0', 'Content-Type': 'application/x-www-form-urlencoded', 'Cookie': 'remixsid=...; remixlang=0; remixsslsid=1'}
```

`response.request.headers` after:
```
{'Content-Length': '141', 'Content-Type': 'application/x-www-form-urlencoded', 'User-agent': 'Mozilla/5.0 (Windows NT 6.1; rv:40.0) Gecko/20100101 Firefox/40.0', 'Cookie': 'remixsid=...; remixlang=0; remixsslsid=1', 'Accept-Encoding': 'gzip, deflate', 'Connection': 'keep-alive', 'Accept': '*/*'}
```