### PR TITLE
Fix VkApiMethod representation for 2.7

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -452,7 +452,7 @@ class VkApi(object):
         return response if raw else response['response']
 
 
-class VkApiMethod:
+class VkApiMethod(object):
     def __init__(self, vk, method=None):
         self._vk = vk
         self._method = method


### PR DESCRIPTION
Для питона 2.7 при попытке распечать VkApiMethod происходит вызов __getattr__, что в итоге приводит к обращению к api vk с ресурсом __str__ (или __repr__)
Пул реквест проверен на питоне 2.7.9 и 3.6.1