### PR TITLE
(-) Skipping song if unavailable

### DIFF
--- a/vk_api/audio.py
+++ b/vk_api/audio.py
@@ -128,8 +128,14 @@ def scrap_data(html):
     soup = BeautifulSoup(html, 'html.parser')
     tracks = []
     for audio in soup.find_all('div', {'class': 'audio_item'}):
-        ai_artist = audio.select('.ai_artist')
-        artist = ai_artist[0].text
+        if 'audio_item_disabled' in audio["class"]:
+            # TODO: implement getting data of unavailable track
+            continue
+
+        artist = audio.select('.ai_artist')[0].text
+        title = audio.select('.ai_title')[0].text
+        duration = audio.select('.ai_dur')[0]['data-dur']
+        track_id = audio['id']
         link = audio.select('.ai_body')[0].input['value']
 
         if 'audio_api_unavailable' in link:
@@ -137,9 +143,9 @@ def scrap_data(html):
 
         tracks.append({
             'artist': artist,
-            'title': audio.select('.ai_title')[0].text,
-            'dur': audio.select('.ai_dur')[0]['data-dur'],
-            'id': audio['id'],
+            'title': title,
+            'dur': duration,
+            'id': track_id,
             'url': link
         })
 


### PR DESCRIPTION
If song is not available due to requests of the copyright holder it has following tag:
`<div class="audio_item audio_item_disabled"></div>` so we can't extract any info from it and  `audio.select('.ai_artist')` will return empty list. After that we'll get **IndexError: list index out of range**.

So I think it'll be good to check if tag is not containing class named 'audio_item_disabled'.
But how can we tell user about this by API?