### PR TITLE
Fix "Unknown auth error" when account is actually blocked

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -402,6 +402,9 @@ class VkApi(object):
                 'response_type': 'token'
             }
         )
+        
+        if 'act=blocked' in response.url:
+            raise AccountBlocked('Account is blocked')
 
         if 'access_token' not in response.url:
             url = search_re(RE_TOKEN_URL, response.text)


### PR DESCRIPTION
Some time ago a weird exception started to appear: "Unknown API auth error".
After debugging I noticed that an app token is never acquired and 

```python
response = self.http.get(
            'https://oauth.vk.com/authorize',
            params={
                'client_id': self.app_id,
                'scope': self.scope,
                'response_type': 'token'
            }
        )
```
is actually returning "Your account has been banned" page. So I have added two lines to clarify the auth exception.