### PR TITLE
Fixed/reworked VkTools.get_all_slow_iter method

### DIFF
--- a/vk_api/exceptions.py
+++ b/vk_api/exceptions.py
@@ -155,3 +155,7 @@ class VkAudioException(Exception):
 
 class VkAudioUrlDecodeError(VkAudioException):
     pass
+
+
+class VkToolsException(VkApiError):
+    pass

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -97,7 +97,7 @@ class VkTools(object):
             offset = response['offset']
 
     def get_all(self, method, max_count, values=None, key='items', limit=None,
-                stop_fn=None):
+                stop_fn=None, negative_offset=False):
         """ Использовать только если нужно загрузить все объекты в память.
 
             Eсли вы можете обрабатывать объекты по частям, то лучше
@@ -108,7 +108,9 @@ class VkTools(object):
         """
 
         items = list(
-            self.get_all_iter(method, max_count, values, key, limit, stop_fn)
+            self.get_all_iter(
+                method, max_count, values, key, limit, stop_fn, negative_offset
+            )
         )
 
         return {'count': len(items), key: items}
@@ -185,7 +187,7 @@ class VkTools(object):
             count = new_count
 
     def get_all_slow(self, method, max_count, values=None, key='items',
-                     limit=None, stop_fn=None):
+                     limit=None, stop_fn=None, negative_offset=False):
         """ Использовать только если нужно загрузить все объекты в память.
 
             Eсли вы можете обрабатывать объекты по частям, то лучше
@@ -197,7 +199,7 @@ class VkTools(object):
 
         items = list(
             self.get_all_slow_iter(
-                method, max_count, values, key, limit, stop_fn
+                method, max_count, values, key, limit, stop_fn, negative_offset
             )
         )
         return {'count': len(items), key: items}
@@ -225,10 +227,10 @@ vk_get_all_items = VkFunction(
         if (count_diff < 0) {
             offset = offset + count_diff;
         } else {
-            ri = response.%(key)s.slice(count_diff);
-            items = items + ri;
+            ri = response.%(key)s;
+            items = items + ri.slice(count_diff);
             offset = offset + params.count + count_diff;
-            if (ri.length < params.count - count_diff) {
+            if (ri.length < params.count) {
                 calls = 99;
             }
         }

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -78,7 +78,7 @@ class VkTools(object):
                     'Can\'t load items. Check access to requested items'
                 )
 
-            items = response['items']
+            items = response[key]
             items_count += len(items)
 
             for item in items:
@@ -172,7 +172,7 @@ class VkTools(object):
             for item in items:
                 yield item
 
-            if len(response_items) < max_count:
+            if len(response_items) < max_count - count_diff:
                 break
 
             if limit and items_count >= limit:
@@ -228,7 +228,7 @@ vk_get_all_items = VkFunction(
             ri = response.%(key)s.slice(count_diff);
             items = items + ri;
             offset = offset + params.count + count_diff;
-            if (ri.length < params.count) {
+            if (ri.length < params.count - count_diff) {
                 calls = 99;
             }
         }

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -200,7 +200,7 @@ vk_get_all_items = VkFunction(
         calls = calls + 1;
         var response = API.%(method)s(params), 
             new_count = response.count,
-            count_diff = (count == null : 0 ? new_count - count);
+            count_diff = (count == null ? 0 : new_count - count);
 
         if (new_count == 0) {
             calls = 25;

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -138,6 +138,15 @@ class VkTools(object):
             response = self.vk.method(method, values)
             new_count = response['count']
             count_diff = new_count-(count or new_count)
+
+            if new_count == 0:
+                break
+
+            if count_diff < 0:
+                values['offset'] += count_diff
+                count = new_count
+                continue
+
             items = response[key][count_diff:]
             items_count += len(items)
 

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -136,7 +136,7 @@ class VkTools(object):
         count = response['count']
         items_count = 0
 
-        for offset in range(max_count, count + 1, max_count):
+        for offset in range(0, count + 1, max_count):
             values['offset'] = offset
 
             response = self.vk.method(method, values)

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -147,7 +147,7 @@ class VkTools(object):
 
         offset_mul = -1 if negative_offset else 1
 
-        offset = 0
+        offset = max_count if negative_offset else 0
         count = None
 
         items_count = 0

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -100,7 +100,7 @@ class VkTools(object):
         return {'count': len(items), key: items}
 
     def get_all_slow_iter(self, method, max_count, values=None, key='items',
-                          limit=None, stop_fn=None):
+                          limit=None, stop_fn=None, negative_offset=False):
         """ Получить все элементы (без использования execute)
         Работает в методах, где в ответе есть count и items или users
 
@@ -126,13 +126,16 @@ class VkTools(object):
         """
 
         values = values.copy() if values else {}
-
         values['count'] = max_count
         values['offset'] = 0
+
+        offset_mul = -1 if negative_offset else 1
         items_count = 0
         count = None
         while values['offset'] < (count or 1):
+            values['offset'] *= offset_mul
             response = self.vk.method(method, values)
+            values['offset'] *= offset_mul
             new_count = response['count']
             count_diff = new_count - (count or new_count)
 
@@ -145,6 +148,8 @@ class VkTools(object):
                 continue
 
             items = response[key][count_diff:]
+            if not items:
+                break
             items_count += len(items)
 
             for item in items:

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -65,20 +65,11 @@ class VkTools(object):
 
         while values['offset'] < (count or 1):
             response = vk_get_all_items(
-                self.vk, method=method, key=key, values=values, count = count
+                self.vk, method=method, key=key, values=values, count=count
             )
-            new_count = response['count']
-            count_diff = new_count-(count or new_count)
+            count = response['count']
 
-            if new_count == 0:
-                break
-
-            if count_diff < 0:
-                values['offset'] += count_diff
-                count = new_count
-                continue
-
-            items = response[key][count_diff:]
+            items = response[key]
             items_count += len(items)
 
             for item in items:
@@ -90,8 +81,7 @@ class VkTools(object):
             if stop_fn and stop_fn(items):
                 break
 
-            values['offset'] += len(items) + count_diff
-            count = new_count
+            values['offset'] = response['offset']
 
     def get_all(self, method, max_count, values=None, key='items', limit=None,
                 stop_fn=None):
@@ -201,7 +191,6 @@ vk_get_all_items = VkFunction(
         var response = API.%(method)s(params), 
             new_count = response.count,
             count_diff = (count == null ? 0 : new_count - count);
-
         if (new_count == 0) {
             calls = 25;
         } else if (count_diff < 0) {
@@ -209,10 +198,10 @@ vk_get_all_items = VkFunction(
             count = new_count;
         } else {
             items = items + response.%(key)s.slice(count_diff);
-            params.offset = params.offset+  params.count + count_diff;
+            params.offset = params.offset + params.count + count_diff;
             count = new_count;
         }
     };
 
-    return {count: count, items: items};
+    return {count: count, items: items, offset: params.offset};
 ''')

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -65,7 +65,7 @@ class VkTools(object):
 
         while values['offset'] < (count or 1):
             response = vk_get_all_items(
-                self.vk, method=method, key=key, values=values
+                self.vk, method=method, key=key, values=values, count = count
             )
             new_count = response['count']
             count_diff = new_count-(count or new_count)
@@ -188,23 +188,19 @@ class VkTools(object):
 
 
 vk_get_all_items = VkFunction(
-    args=('method', 'key', 'values'),
+    args=('method', 'key', 'values', 'count'),
     clean_args=('method', 'key'),
     code='''
     var params = %(values)s,
         calls = 0,
         items = [],
-        count, new_count, count_diff, response;
+        count = %(count)s;
 
     while(calls < 25 && (count == null || params.offset < count)) {
         calls = calls + 1;
-        response = API.%(method)s(params);
-        new_count = response.count;
-
-        if (count == null) {
-            count = new_count;
-        }
-        count_diff = new_count - count;
+        var response = API.%(method)s(params), 
+            new_count = response.count,
+            count_diff = (count == null : 0 ? new_count - count);
 
         if (new_count == 0) {
             calls = 25;

--- a/vk_api/tools.py
+++ b/vk_api/tools.py
@@ -78,7 +78,7 @@ class VkTools(object):
                     'Can\'t load items. Check access to requested items'
                 )
 
-            items = response[key]
+            items = response["items"]
             items_count += len(items)
 
             for item in items:


### PR DESCRIPTION
Сначала я заметил, что в текущей реализации обрезаются первые max_count результатов. Это исправил в первом коммите.

Затем, мне там же не понравились две вещи:
1. Отдельный запрос только для того, чтобы узнать количество результатов
2. Во время выполнения цикла количество элементов может измениться, и это надо учитывать

Так что вторым коммитом идёт моя реализация этого метода