### PR TITLE
Замена получаемого результата execute_one_param() с dict на OrderedDict

### DIFF
--- a/vk_api/requests_pool.py
+++ b/vk_api/requests_pool.py
@@ -9,6 +9,7 @@
 
 import sys
 from collections import namedtuple
+from collections import OrderedDict
 
 from .utils import sjson_dumps
 from .execute import VkFunction
@@ -186,7 +187,7 @@ class VkRequestsPool(object):
                     cur_pool[x].result.error = True
 
     def execute_one_param(self):
-        result = {}
+        result = OrderedDict()
 
         method = self.one_param['method']
         default = self.one_param['default']


### PR DESCRIPTION
В питоне 3.6+ словари упорядочены. Для того, что бы получаемые результаты были упорядочены и в, например, питоне версии 3.5., возвращаемый результат можно заменить на OrderedDict