### PR TITLE
Make module Windows-installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 version = '11.0.0'
 
-with open('README.md') as f:
+with open('README.md', encoding="utf-8") as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Specify `open` encoding. Because, for example, on Windows 10 + Conda + Python 3.6 environment:
```
Collecting vk_api==11.0.0 (from -r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/ac/c6/7ab7b58b00c6b06af38ce244515e4c6ad6b8fae0c00d4931c63bcdc803f3/vk_api-11.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\pchelkin\AppData\Local\Temp\5\pip-install-nqlywbl6\vk-api\setup.py", line 16, in <module>
        long_description = f.read()
      File "C:\Users\pchelkin\AppData\Local\Continuum\miniconda3\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 222: character maps to <undefined>
```