### PR TITLE
fix / get audio from the album

### DIFF
--- a/vk_api/audio.py
+++ b/vk_api/audio.py
@@ -16,6 +16,7 @@ from .exceptions import AccessDenied
 
 RE_AUDIO_ID = re.compile(r'audio(-?\d+)_(\d+)')
 RE_ALBUM_ID = re.compile(r'act=audio_playlist(-?\d+)_(\d+)')
+RE_ACCESS_HASH = re.compile(r'access_hash=(\w+)')
 
 TRACKS_PER_USER_PAGE = 50
 TRACKS_PER_ALBUM_PAGE = 100
@@ -35,19 +36,20 @@ class VkAudio(object):
         self.user_id = vk.method('users.get')[0]['id']
         self._vk = vk
 
-    def get_iter(self, owner_id=None, album_id=None):
+    def get_iter(self, owner_id=None, album_id=None, access_hash=None):
         """ Получить список аудиозаписей пользователя (по частям)
 
         :param owner_id: ID владельца (отрицательные значения для групп)
         :param album_id: ID альбома
+        :param access_hash: ACCESS_HASH альбома
         """
 
         if owner_id is None:
             owner_id = self.user_id
 
         if album_id is not None:
-            url = 'https://m.vk.com/audio?act=audio_playlist{}_{}'.format(
-                owner_id, album_id
+            url = 'https://m.vk.com/audio?act=audio_playlist{}_{}&access_hash={}'.format(
+                owner_id, album_id, access_hash or ''
             )
             offset_diff = TRACKS_PER_ALBUM_PAGE
         else:
@@ -69,7 +71,11 @@ class VkAudio(object):
                     'You don\'t have permissions to browse user\'s audio'
                 )
 
-            tracks = scrap_data(response.text, self.user_id)
+            tracks = scrap_data(
+                response.text,
+                self.user_id,
+                filter_root_el={'class_': 'audioPlaylist__list'} if album_id else None
+            )
 
             if not tracks:
                 break
@@ -79,14 +85,15 @@ class VkAudio(object):
 
             offset += offset_diff
 
-    def get(self, owner_id=None, album_id=None):
+    def get(self, owner_id=None, album_id=None, access_hash=None):
         """ Получить список аудиозаписей пользователя
 
         :param owner_id: ID владельца (отрицательные значения для групп)
         :param album_id: ID альбома
+        :param access_hash: ACCESS_HASH альбома
         """
 
-        return list(self.get_iter(owner_id, album_id))
+        return list(self.get_iter(owner_id, album_id, access_hash))
 
     def get_albums_iter(self, owner_id=None):
         """ Получить список альбомов пользователя (по частям)
@@ -255,11 +262,12 @@ def scrap_albums(html):
 
         link = album.select_one('.audioPlaylistsPage__itemLink')['href']
         full_id = tuple(int(i) for i in RE_ALBUM_ID.search(link).groups())
+        access_hash = RE_ACCESS_HASH.search(link)
 
         stats_text = album.select_one('.audioPlaylistsPage__stats').text
 
-        # "1 011 прослушиваний"
-        plays = int(stats_text.rsplit(' ', 1)[0].replace(' ', ''))
+        # "1 011 прослушиваний" / -1 если отсутствуют кол. прослушиваний
+        plays = -1 if '·' in stats_text else int(stats_text.rsplit(' ', 1)[0].replace(' ', ''))
 
         albums.append({
             'id': full_id[1],
@@ -267,6 +275,7 @@ def scrap_albums(html):
             'url': 'https://m.vk.com/audio?act=audio_playlist{}_{}'.format(
                 *full_id
             ),
+            'access_hash': access_hash.group(1) if access_hash else None,
 
             'title': album.select_one('.audioPlaylistsPage__title').text,
             'plays': plays

--- a/vk_api/audio.py
+++ b/vk_api/audio.py
@@ -266,8 +266,11 @@ def scrap_albums(html):
 
         stats_text = album.select_one('.audioPlaylistsPage__stats').text
 
-        # "1 011 прослушиваний" / None если отсутствуют кол. прослушиваний
-        plays = None if '·' in stats_text else int(stats_text.rsplit(' ', 1)[0].replace(' ', ''))
+        # "1 011 прослушиваний"
+        try:
+            plays = int(stats_text.rsplit(' ', 1)[0].replace(' ', ''))
+        except ValueError:
+            plays = None
 
         albums.append({
             'id': full_id[1],

--- a/vk_api/audio.py
+++ b/vk_api/audio.py
@@ -266,8 +266,8 @@ def scrap_albums(html):
 
         stats_text = album.select_one('.audioPlaylistsPage__stats').text
 
-        # "1 011 прослушиваний" / -1 если отсутствуют кол. прослушиваний
-        plays = -1 if '·' in stats_text else int(stats_text.rsplit(' ', 1)[0].replace(' ', ''))
+        # "1 011 прослушиваний" / None если отсутствуют кол. прослушиваний
+        plays = None if '·' in stats_text else int(stats_text.rsplit(' ', 1)[0].replace(' ', ''))
 
         albums.append({
             'id': full_id[1],


### PR DESCRIPTION
fix https://github.com/python273/vk_api/issues/196

добавил получения аудио из альбома с `access_hash`
```python
albums = vkaudio.get_albums(194957739)[0]
tracks = vkaudio.get(owner_id=albums['owner_id'], album_id=albums['id'], access_hash=albums['access_hash'])
```
на кол. прослушиваний ( `plays` ) -1 если отсутствуют ([пример плейлиста](https://m.vk.com/audio?act=audio_playlists194957739))
![image](https://user-images.githubusercontent.com/31490684/49669433-0ad4dd80-fa6a-11e8-9258-e7427bd25c6e.png)
