### PR TITLE
Fix keyword attribute in longpoll.Event object; missing import

### DIFF
--- a/vk_api/longpoll.py
+++ b/vk_api/longpoll.py
@@ -392,6 +392,11 @@ class Event(object):
         if self.timestamp:
             self.datetime = datetime.utcfromtimestamp(self.timestamp)
 
+    def __setattr__(self, name, value):
+        if name == 'from': # Избегаем недосягаемых параметров
+            name = 'from_id'
+        object.__setattr__(self, name, value)
+
     def _list_to_attr(self, raw, attrs):
         for i in range(min(len(raw), len(attrs))):
             self.__setattr__(attrs[i], raw[i])

--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -12,6 +12,7 @@ import re
 import threading
 import time
 
+import six
 import requests
 
 import jconfig


### PR DESCRIPTION
Недосягаемый аргумент from в extra_fields недоступен, так как является Python-кейвордом (наряду с pass, in, for и т.д.).
В vk_api.py используется six.iteritems, но самого импорта нет. 