### PR TITLE
Added enum-compat instead of enum34 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
 requests
-enum34
+enum-compat
 websocket-client
 six


### PR DESCRIPTION
As stated in Issue #217, the package enum34 is no longer required in Python >= 3.4, thus, it may cause issues with other tools such as Pyinstaller if present in the Python package list. The enum-compat package installs enum34 in Python < 3.4 and does nothing in Python > 3.4 so it doesn't break compatibility. This should fix #217