### PR TITLE
Cast longpoll mode to int

### DIFF
--- a/vk_api/longpoll.py
+++ b/vk_api/longpoll.py
@@ -489,7 +489,10 @@ class VkLongPoll(object):
     def __init__(self, vk, wait=25, mode=DEFAULT_MODE, preload_messages=False):
         self.vk = vk
         self.wait = wait
-        self.mode = mode
+
+        # Иначе название константы может оказаться в запросе к API
+        self.mode = int(mode)
+
         self.preload_messages = preload_messages
 
         self.url = None

--- a/vk_api/longpoll.py
+++ b/vk_api/longpoll.py
@@ -489,10 +489,7 @@ class VkLongPoll(object):
     def __init__(self, vk, wait=25, mode=DEFAULT_MODE, preload_messages=False):
         self.vk = vk
         self.wait = wait
-
-        # Иначе название константы может оказаться в запросе к API
-        self.mode = int(mode)
-
+        self.mode = mode.value if isinstance(mode, VkLongpollMode) else mode
         self.preload_messages = preload_messages
 
         self.url = None


### PR DESCRIPTION
Bugfix. Current code produces request like:
`https://imv4.vk.com/im3666?act=a_check&key=1234&ts=56&wait=25&mode=VkLongpollMode.GET_PTS`
when a single enum element is used without bitwise operations.

Seems like VK just ignores such values, that's why this bug is so hard to notice.