### PR TITLE
Require enum34 conditionally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
 requests
-enum34
+enum34;python_version<"3.4"
 websocket-client
 six

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     license='Apache License, Version 2.0, see LICENSE file',
 
     packages=['vk_api', 'jconfig'],
-    install_requires=['requests', 'enum34', 'six'],
+    install_requires=['requests', 'enum34;python_version<"3.4"', 'six'],
     extras_require={
         'vkstreaming': ['websocket-client'],
         'vkaudio': ['beautifulsoup4'],


### PR DESCRIPTION
Another attempt (previous was #251), now using a [more elegant solution](https://www.python.org/dev/peps/pep-0508/#environment-markers). Fixes #217.

`enum34` breaks even pip (at least in some cases), that's very annoying and needs a quick fix.