### PR TITLE
add use case for VkRequestsPool

### DIFF
--- a/examples/requests_pool.py
+++ b/examples/requests_pool.py
@@ -63,6 +63,25 @@ def main():
 
     print(friends)
 
+    """Пример использования пула в виде объекта. Такой пул можно
+    передать в качестве параметра"""
+
+    friends = {}
+    
+    pool = vk_api.VkRequestsPool(vk_session)
+    for user_id in [1, 183433824]:
+        friends[user_id] = pool.method('friends.get', {
+            'user_id': user_id,
+            'fields': 'photo'
+        })
+        
+    pool.execute()
+
+    for key, value in friends.items():
+        friends[key] = value.result
+
+    print(friends)
+
     """ Следующий пример - более простая версия предыдущего
 
         В friends будет записан тот же самый результат, что и в прошлом примере.

--- a/vk_api/requests_pool.py
+++ b/vk_api/requests_pool.py
@@ -70,8 +70,12 @@ class VkRequestsPool(object):
     Позволяет сделать несколько обращений к API за один запрос
     за счет метода execute.
 
-    Служит как менеджер контекста: запросы к API добавляются в
+    Варианты использованя:
+    - В качестве менеджера контекста: запросы к API добавляются в
     открытый пул, и выполняются при его закрытии.
+    - В качестве объекта пула. запросы к API дабвляются по одному
+    в пул и выполняются все вместе при выполнении метода execute()
+
 
     :param vk_session: Объект :class:`VkApi`
     """
@@ -110,6 +114,11 @@ class VkRequestsPool(object):
         return result
 
     def execute(self):
+        """
+        Выполняет все находящиеся в пуле запросы и отчищает пул.
+        Необходим для использования пула-объекта.
+        Для пула менеджера контекста вызывается автоматически.
+        """
         for i in range(0, len(self.pool), 25):
             cur_pool = self.pool[i:i + 25]
 
@@ -136,6 +145,7 @@ class VkRequestsPool(object):
                     current_result.result = current_response
                 else:
                     current_result.error = next(response_errors_iter)
+        self.pool = []
 
 
 def check_one_method(pool):


### PR DESCRIPTION
Добавлен вариант использования пула как объекта. Обновлена соответствующая документация и пример. Изменен метод execute класса VkRequestsPool. Теперь пул автоматически обнуляется после исполнения.