### PR TITLE
Fix from_id

### DIFF
--- a/vk_api/bot_longpoll.py
+++ b/vk_api/bot_longpoll.py
@@ -167,10 +167,11 @@ class VkBotMessageEvent(VkBotEvent):
         self.chat_id = None
 
         peer_id = self.obj.peer_id or self.message.peer_id
-        
-        if peer_id < 0:
+        from_id = self.obj.from_id or self.message.from_id
+        # если id отрицательный - это группа
+        if from_id < 0:
             self.from_group = True
-        elif peer_id < CHAT_START_ID:
+        if peer_id < CHAT_START_ID:
             self.from_user = True
         else:
             self.from_chat = True


### PR DESCRIPTION
Раньше никак не реагировало на группу, ибо была заданна неправильная переменная.
Пример сообщения от пользователя:
```json
{
    "date": 1594312002,
    "from_id": 499950380,
    "id": 0,
    "out": 0,
    "peer_id": 2000000001,
    "text": "312",
    "conversation_message_id": 12808,
    "fwd_messages": [
      
    ],
    "important": false,
    "random_id": 0,
    "attachments": [
      
    ],
    "
```
Пример сообщения от группы:
```json
{
    "date": 1594312003,
    "from_id": -170233524,
    "id": 0,
    "out": 0,
    "peer_id": 2000000001,
    "text": "123",
    "conversation_message_id": 12809,
    "fwd_messages": [
      
    ],
    "important": false,
    "random_id": 0,
    "attachments": [
      
    ],
    "is_hidden": false
  }
```