### PR TITLE
Tiny fix to http session

### DIFF
--- a/vk_api/longpoll.py
+++ b/vk_api/longpoll.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from enum import IntEnum
 
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 CHAT_START_ID = int(2E9)  # id с которого начинаются беседы
 
@@ -511,6 +513,9 @@ class VkLongPoll(object):
         self.pts = mode & VkLongpollMode.GET_PTS
 
         self.session = requests.Session()
+        self.retry = Retry(connect=3, backoff_factor=0.33)
+        self.http_adapter = HTTPAdapter(max_retries=self.retry)
+        self.session.mount('https://', self.http_adapter)
 
         self.update_longpoll_server()
 

--- a/vk_api/longpoll.py
+++ b/vk_api/longpoll.py
@@ -12,7 +12,10 @@ from enum import IntEnum
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+try:
+    from requests.packages.urllib3.util.retry import Retry
+except ImportError:
+    from requests.adapters import Retry
 
 CHAT_START_ID = int(2E9)  # id с которого начинаются беседы
 
@@ -513,7 +516,7 @@ class VkLongPoll(object):
         self.pts = mode & VkLongpollMode.GET_PTS
 
         self.session = requests.Session()
-        self.retry = Retry(connect=3, backoff_factor=0.33)
+        self.retry = Retry(connect=0, backoff_factor=0.33)
         self.http_adapter = HTTPAdapter(max_retries=self.retry)
         self.session.mount('https://', self.http_adapter)
 


### PR DESCRIPTION
Sometimes vk forcibly breaks longpool connection (more often than not it happens at night). At current realization VKLongPoll tries immediately restore one. In this case, the requests.exceptions.ConnectionError is raised. My patch may help to avoid this.