### PR TITLE
Fixed multiple 'remixsid' cookies conflict

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -135,8 +135,8 @@ class VkApi(object):
     @property
     def _sid(self):
         return (
-            self.http.cookies.get('remixsid') or
-            self.http.cookies.get('remixsid6')
+            self.http.cookies.get('remixsid', domain='.vk.ru') or
+            self.http.cookies.get('remixsid6', domain='.vk.ru')
         )
 
     def auth(self, reauth=False, token_only=False):


### PR DESCRIPTION
Added 'domain='.vk.ru'' in Vkapi._sid function to resolve 'multiple cookies with the same name' conflict (cookies are the same for .vk.com and .vk.ru)