### PR TITLE
Sanitize json with control characters

### DIFF
--- a/vk_api/vk_api.py
+++ b/vk_api/vk_api.py
@@ -665,7 +665,11 @@ class VkApi(object):
             self.last_request = time.time()
 
         if response.ok:
-            response = response.json()
+            try:
+                response = response.json()
+            except json.decoder.JSONDecodeError:
+                sanitized = rx.sub(r'\p{C}', '', response.content)
+                response = json.loads(sanitized)
         else:
             error = ApiHttpError(self, method, values, raw, response)
             response = self.http_handler(error)


### PR DESCRIPTION
Hi!

I recently saw that VK seems to be really bad at sanitizing some fields such as usernames.
Loading a bunch of members with vk_api yielded an ugly 
`JSONDecodeError: Invalid control character at: line 1 column 68248 (char 68247)`

Inspecting this by hand, I found that the response contains this abomination:

```
In [32]: e[68200:68259]
Out[32]: ',"is_closed":false},{"id":27497241,"nickname":"\x01","domain":'
```
Of course, <0x01> is not a codepoint that you'd want in a nickname, ever!

Since the data is nonsensical, not printable and potentially dangerous, my suggestion would be to catch `JSONDecodeError`s and try to sanitize the raw content before parsing it with json.loads.

There are many options for replacing the problematic characters, but regex should be reasonably fast. As a bonus, it allows us to catch control characters as a category (`\p{C}`) rather than listing them by hand.