### PR TITLE
Make jconfig.memory.MemoryConfig more accessible

### DIFF
--- a/jconfig/__init__.py
+++ b/jconfig/__init__.py
@@ -11,3 +11,4 @@ __version__ = '3.0'
 __email__ = 'vk_api@python273.pw'
 
 from .jconfig import Config
+from .memory import MemoryConfig


### PR DESCRIPTION
This change makes it easier to access the MemoryConfig class much easier.

When working temporarily (REPL) I do not like having config files created because I forget to remove them
It is currently possible to access the MemoryConfig class as follow
```python
from  jconfig.memory import MemoryConfig
vk_session = vk_api.VkApi(login, password, config=MemoryConfig)
```
however this fails
```python
import jconfig
vk_session = vk_api.VkApi(login, password, config=jconfig.memory.MemoryConfig)
```
There are no examples in the code but the [documentation](https://vk-api.readthedocs.io/en/latest/jconfig.html) suggests that this is the right way to call it.

![Google Translate](https://ssl.gstatic.com/translate/favicon.ico)

Это изменение значительно упрощает доступ к классу MemoryConfig.

При временной работе (REPL) мне не нравится создавать файлы конфигурации, потому что я забываю их удалить
В настоящее время можно получить доступ к классу MemoryConfig следующим образом.
```python
from jconfig.memory import MemoryConfig
vk_session = vk_api.VkApi(login, password, config=MemoryConfig)
```
однако это не удается
```python
import jconfig
vk_session = vk_api.VkApi(login, password, config=jconfig.memory.MemoryConfig)
```
В коде нет примеров, но [документация](https://vk-api.readthedocs.io/en/latest/jconfig.html) предполагает, что это правильный способ вызова.

![Yandex Translate](https://translate.yandex.com/icons/favicon.ico)

Это изменение значительно упрощает доступ к классу конфигурации памяти.

При временной работе (ОТВЕТ) Мне не нравится, когда создаются конфигурационные файлы, потому что я забываю их удалять
В настоящее время можно получить доступ к классу конфигурации памяти следующим образом
```python
from  jconfig.memory import MemoryConfig
vk_session = vk_api.VkApi(login, password, config=MemoryConfig)
```
однако это не удается
```python
import jconfig
vk_session = vk_api.VkApi(login, password, config=jconfig.memory.MemoryConfig)
```
В коде нет примеров, кроме [документации](https://vk-api.readthedocs.io/en/latest/jconfig.html ) предполагает, что это правильный способ назвать это.

