### PR TITLE
🐞 fix PEP 8: W605 invalid escape sequence '\*'

### DIFF
--- a/vk_api/execute.py
+++ b/vk_api/execute.py
@@ -44,8 +44,8 @@ class VkFunction(object):
     def __call__(self, vk, *args, **kwargs):
         """
         :param vk: VkApi или VkApiMethod
-        :param \*args:
-        :param \*\*kwargs:
+        :param *args:
+        :param **kwargs:
         """
 
         if not isinstance(vk, (VkApi, VkApiMethod)):


### PR DESCRIPTION
fixing an error 

```
E       """ Абстрактный базовый класс конфигурации.
E       ^
E   SyntaxError: invalid escape sequence \*

```